### PR TITLE
Add Lisp

### DIFF
--- a/lisp/hello_world.cl
+++ b/lisp/hello_world.cl
@@ -1,0 +1,2 @@
+// greet the user
+(write-line "Hello, world!")


### PR DESCRIPTION
Adds a Lisp example. The error is that it's using a C++-style comment (//) instead of a Lisp-style comment (;).
